### PR TITLE
Remove R10

### DIFF
--- a/PoElli/PoElli-Nucleo.brd
+++ b/PoElli/PoElli-Nucleo.brd
@@ -2439,6 +2439,8 @@ design rules under a new name.</description>
 <wire x1="67" y1="3.2" x2="66.3" y2="3.2" width="0.4" layer="1"/>
 <wire x1="66.3" y1="3.2" x2="65.9" y2="3.6" width="0.4" layer="1"/>
 <wire x1="65.9" y1="3.6" x2="65.9" y2="4.9" width="0.4" layer="1"/>
+<contactref element="C21" pad="2"/>
+<wire x1="67" y1="3.2" x2="69.45" y2="4.9" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="POE_A+" class="1">
 <contactref element="D14" pad="C"/>
@@ -3572,9 +3574,6 @@ design rules under a new name.</description>
 <wire x1="3.3" y1="15.4" x2="3.3" y2="15.9" width="0.15" layer="1"/>
 <wire x1="3.3" y1="15.9" x2="3.135" y2="16.065" width="0.15" layer="1"/>
 <wire x1="3.135" y1="16.065" x2="3.135" y2="16.3" width="0.15" layer="1"/>
-</signal>
-<signal name="N$9">
-<contactref element="C21" pad="2"/>
 </signal>
 <signal name="N$199">
 <polygon width="0.2" layer="15" pour="cutout">

--- a/PoElli/PoElli-Nucleo.sch
+++ b/PoElli/PoElli-Nucleo.sch
@@ -5287,12 +5287,13 @@ replacement of R29</text>
 <net name="N$33" class="0">
 <segment>
 <pinref part="D3" gate="G$1" pin="C"/>
-<wire x1="17.78" y1="93.98" x2="10.16" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="10.16" y1="101.6" x2="10.16" y2="93.98" width="0.1524" layer="91"/>
 <pinref part="R16" gate="G$1" pin="1"/>
-<wire x1="0" y1="93.98" x2="10.16" y2="93.98" width="0.1524" layer="91"/>
-<junction x="10.16" y="93.98"/>
-<wire x1="7.62" y1="101.6" x2="10.16" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="0" y1="93.98" x2="7.62" y2="93.98" width="0.1524" layer="91"/>
+<pinref part="C21" gate="G$1" pin="2"/>
+<wire x1="7.62" y1="93.98" x2="17.78" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="101.6" x2="7.62" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="7.62" y1="101.6" x2="7.62" y2="93.98" width="0.1524" layer="91"/>
+<junction x="7.62" y="93.98"/>
 </segment>
 </net>
 <net name="POE_A+" class="1">
@@ -6338,12 +6339,6 @@ replacement of R29</text>
 <wire x1="342.9" y1="304.8" x2="342.9" y2="292.1" width="0.1524" layer="91"/>
 <wire x1="342.9" y1="292.1" x2="337.82" y2="292.1" width="0.1524" layer="91"/>
 <pinref part="CN7" gate="CN7" pin="PD2_4"/>
-</segment>
-</net>
-<net name="N$9" class="0">
-<segment>
-<pinref part="C21" gate="G$1" pin="2"/>
-<wire x1="7.62" y1="101.6" x2="-5.08" y2="101.6" width="0.1524" layer="91"/>
 </segment>
 </net>
 </nets>


### PR DESCRIPTION
Remove R10 based on experiences with the prototype. Design should have less ringing and smaller voltage kickbacks from flyback afterwards.
